### PR TITLE
Show what a v tag asserts, beside what main carries

### DIFF
--- a/alembic/versions/2026_08_11_0002_008_release_state.py
+++ b/alembic/versions/2026_08_11_0002_008_release_state.py
@@ -1,0 +1,46 @@
+"""Add the release layer to the governance read model.
+
+Revision ID: 008_release
+Revises: 007_reclaim
+Create Date: 2026-08-11
+
+`main` is readiness; a `v` tag is governance passed. The corpus's harness
+document now carries a `release` layer per repository, and these columns hold
+it: the state, the latest tag, whether that tag is annotated, and how many
+commits the default branch carries beyond it.
+
+Stored as a value plus an `unknown` reason, like every other measurable fact
+here. A repository whose tags could not be read must not render like one that
+has none.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+revision: str = '008_release'
+down_revision: Union[str, None] = '007_reclaim'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+COLUMNS = (
+    ('release_state', sqlmodel.sql.sqltypes.AutoString()),
+    ('release_unknown', sqlmodel.sql.sqltypes.AutoString()),
+    ('release_latest', sqlmodel.sql.sqltypes.AutoString()),
+    ('release_annotated', sa.Boolean()),
+    ('release_unreleased_commits', sa.Integer()),
+)
+
+
+def upgrade() -> None:
+    for name, kind in COLUMNS:
+        op.add_column('governance_repository', sa.Column(name, kind, nullable=True))
+
+
+def downgrade() -> None:
+    for name, _ in reversed(COLUMNS):
+        op.drop_column('governance_repository', name)

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -183,6 +183,7 @@ project nobody has synced is exactly the one that stays invisible.
 | CORPUS | commits behind the corpus, or `current` |
 | SEED | whether the project's `adr/` seed matches the corpus's |
 | SLOT | `ok`, `over`, or `unknown` against one-open-PR-per-contributor |
+| RELEASE | what a `v` tag asserts, beside what the default branch carries past it |
 | EVIDENCE | what has actually landed on the project's default branch |
 
 The gap between PHASE and EVIDENCE is the point of putting them side by side.
@@ -201,6 +202,24 @@ Stages are `local`, `pushed`, `draft`, `ready` — **observable states, not
 progress**. Nothing here estimates completion: the corpus has no definition of
 done a tool could read, and a percentage would be the most confidently wrong
 thing this view could print.
+
+### `main` is readiness; a `v` tag is governance
+
+Merging asserts the work is ready to build on, and nothing more. A `v` tag
+asserts what the version-tags record requires: a human reviewed it, a human
+manually tested it against its real runtime, and its automated gate passed and
+is deterministic. The RELEASE column is the gap between them.
+
+| Reads | Means |
+|---|---|
+| `never tagged` | no `v` tag has ever existed; nothing has ever been asserted |
+| `v0.2.0` | tagged, annotated, and the branch carries nothing beyond it |
+| `v0.2.0 +37` | 37 commits of readiness waiting on governance |
+| `v0.0.1 lightweight` | the tag carries no annotation, so it names neither the reviewer nor the manual test — a claim with nothing behind it |
+| `unknown` | the tags could not be read, with the reason kept |
+
+`never tagged` and a bare version both have nothing outstanding and mean
+opposite things, so one is never rendered as the other.
 
 ### Three states that are deliberately not blank
 

--- a/src/dossier/cli.py
+++ b/src/dossier/cli.py
@@ -2983,7 +2983,7 @@ def governance_show() -> None:
 
     header = (
         f"{'REPOSITORY':<25} {'PHASE':<8} {'CORPUS':<12} {'SEED':<7} "
-        f"{'SLOT':<6} {'IN DOSSIER':<14} EVIDENCE"
+        f"{'SLOT':<6} {'RELEASE':<22} {'IN DOSSIER':<14} EVIDENCE"
     )
     click.echo(header)
     click.echo("-" * len(header))
@@ -3001,6 +3001,7 @@ def governance_show() -> None:
             f"{gov.drift_text(row):<12} "
             f"{gov.show_pair(row.seed_drift, row.seed_drift_unknown):<7} "
             f"{gov.show_pair(row.slot_state, row.slot_unknown):<6} "
+            f"{_fit(gov.release_text(row), 22):<22} "
             f"{_fit(synced.get(row.name), 14):<14} "
             f"{evidence}"
         )
@@ -3009,6 +3010,7 @@ def governance_show() -> None:
     click.echo("! drift   - behind the corpus, seed drift, or over the slot limit")
     click.echo("phase is a claim a human entered; evidence is what has landed")
     click.echo("in dossier - the project this store holds for it, if any")
+    click.echo("release   - main is readiness; a v tag is governance passed")
 
 
 @governance_group.command(name="threads")

--- a/src/dossier/governance.py
+++ b/src/dossier/governance.py
@@ -294,6 +294,11 @@ def _apply_harness(
     row.slot_unknown = repo.slot_unknown
     row.slot_open_prs = repo.slot_open_prs
     row.slot_violations = repo.slot_violations
+    row.release_state = repo.release_state
+    row.release_unknown = repo.release_unknown
+    row.release_latest = repo.release_latest
+    row.release_annotated = repo.release_annotated
+    row.release_unreleased_commits = repo.release_unreleased_commits
 
 
 def _as_datetime(value) -> Optional[datetime]:
@@ -483,6 +488,30 @@ def show_pair(value, unknown: Optional[str], null_text: str = "-") -> str:
     return str(value)
 
 
+def release_text(row: GovernanceRepository) -> str:
+    """What a v tag asserts here, beside what the default branch carries.
+
+    `main` is readiness; a tag is governance passed. `unreleased` and `current`
+    are never rendered as each other -- both have nothing outstanding and they
+    mean opposite things. A lightweight tag is flagged rather than counted as a
+    release: it carries no annotation, so it names neither the reviewer nor the
+    manual test the version-tags record requires.
+    """
+    if row.release_unknown:
+        return UNKNOWN_TEXT
+    if row.release_state is None:
+        return "-"
+    if row.release_state == "unreleased":
+        return "never tagged"
+    flag = "" if row.release_annotated else " lightweight"
+    if row.release_state == "current":
+        return f"{row.release_latest}{flag}"
+    n = row.release_unreleased_commits
+    if n is None:
+        return f"{row.release_latest}{flag} +? unreleased"
+    return f"{row.release_latest}{flag} +{n}"
+
+
 def coverage_text(project, matched_by: Optional[str]) -> str:
     """Whether this store holds the repository, and whether that was a guess.
 
@@ -553,6 +582,7 @@ def summary_lines(row: Optional[GovernanceRepository], matched_by: Optional[str]
         lines.append("never propagated")
     else:
         lines.append(f"last propagation {row.last_propagation:%Y-%m-%d}")
+    lines.append(f"release {release_text(row)}")
     if matched_by and matched_by != "slug":
         lines.append(f"matched to this project by {matched_by}, not by slug")
     return lines

--- a/src/dossier/models/governance.py
+++ b/src/dossier/models/governance.py
@@ -113,6 +113,16 @@ class GovernanceRepository(SQLModel, table=True):
     precondition_unknown: Optional[str] = None
     precondition_missing: Optional[str] = None  # comma-joined, verbatim
 
+    # What a v tag asserts, beside what the default branch carries. `main` is
+    # readiness; a tag is governance passed. The gap between them is the fact
+    # worth storing, and `unreleased` is not `current` -- both have nothing
+    # outstanding and they mean opposite things.
+    release_state: Optional[str] = None
+    release_unknown: Optional[str] = None
+    release_latest: Optional[str] = None
+    release_annotated: Optional[bool] = None
+    release_unreleased_commits: Optional[int] = None
+
     slot_state: Optional[str] = None
     slot_unknown: Optional[str] = None
     slot_open_prs: Optional[int] = None

--- a/src/dossier/parsers/governance.py
+++ b/src/dossier/parsers/governance.py
@@ -259,6 +259,11 @@ class HarnessRepository:
     slot_unknown: Optional[str] = None
     slot_open_prs: Optional[int] = None
     slot_violations: Optional[str] = None
+    release_state: Optional[str] = None
+    release_unknown: Optional[str] = None
+    release_latest: Optional[str] = None
+    release_annotated: Optional[bool] = None
+    release_unreleased_commits: Optional[int] = None
     threads: list[Thread] = dataclass_field(default_factory=list)
 
 
@@ -373,6 +378,7 @@ def load_harness(path: Path | str) -> HarnessDocument:
         name = str(entry["name"])
 
         slot_state, slot_unknown, slot_count, violations = _slots(entry)
+        release = field(entry, "release")
         missing = field(entry, "governance", "missing")
         repositories.append(
             HarnessRepository(
@@ -391,6 +397,15 @@ def load_harness(path: Path | str) -> HarnessDocument:
                 slot_unknown=slot_unknown,
                 slot_open_prs=slot_count,
                 slot_violations=violations,
+                release_state=(
+                    None if release.is_unknown else field(entry, "release", "state").or_none()
+                ),
+                release_unknown=release.unknown,
+                release_latest=field(entry, "release", "latest").or_none(),
+                release_annotated=field(entry, "release", "annotated").or_none(),
+                release_unreleased_commits=field(
+                    entry, "release", "unreleased_commits"
+                ).or_none(),
                 threads=_threads(name, entry.get("threads")),
             )
         )

--- a/src/dossier/tui/app.py
+++ b/src/dossier/tui/app.py
@@ -934,7 +934,8 @@ class DossierApp(App):
         governance_table.add_column("Corpus", width=13)
         governance_table.add_column("Seed", width=8)
         governance_table.add_column("Slot", width=9)
-        governance_table.add_column("Evidence (landed)", width=46)
+        governance_table.add_column("Release", width=22)
+        governance_table.add_column("Evidence (landed)", width=40)
         # The reverse link: which governed repositories this store has synced.
         # A blank here means nobody has looked at that project in dossier, which
         # is worth seeing beside its governance state.
@@ -3026,6 +3027,7 @@ class DossierApp(App):
                 self._governance_cell(
                     gov.show_pair(row.slot_state, row.slot_unknown)
                 ),
+                self._release_cell(gov.release_text(row)),
                 self._governance_cell(evidence),
                 self._coverage_cell(projects.get(row.name, "not synced")),
                 key=f"governance-{row.name}",
@@ -3069,6 +3071,21 @@ class DossierApp(App):
                 self._pr_cell(thread.pr, synced_prs),
                 key=f"thread-{thread.id}",
             )
+
+    @staticmethod
+    def _release_cell(text: str) -> str:
+        """Colour the two states that need a reader's attention.
+
+        Never-tagged is dimmed rather than reddened: it is the normal state of
+        a project nobody has released, not a fault.
+        """
+        if text.startswith("unknown"):
+            return f"[yellow]{text}[/]"
+        if "lightweight" in text:
+            return f"[red]{text}[/]"
+        if text == "never tagged":
+            return f"[dim]{text}[/]"
+        return text
 
     @staticmethod
     def _coverage_cell(text: str) -> str:

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -874,3 +874,68 @@ def test_against_the_vendored_corpus_if_present(session):
     assert report.anything_loaded
     for row in gov.repositories(session):
         assert gov.health(row) in {"ok", "drift", "unknown"}
+
+
+# --- main is readiness; a v tag is governance passed -----------------------
+
+
+def test_the_release_layer_is_stored_with_its_unknown_reason(session, tmp_path):
+    write_harness(
+        tmp_path,
+        [
+            {"name": "qmetronome", "release": {"state": "current", "latest": "v0.2.0",
+                                               "annotated": True, "unreleased_commits": 0}},
+            {"name": "alfred", "release": {"state": "ahead", "latest": "v0.2.0",
+                                           "annotated": False, "unreleased_commits": 37}},
+            {"name": "qm", "release": {"state": "unreleased", "latest": None}},
+            {"name": "mystery", "release": {"unknown": "gh: Not Found"}},
+        ],
+    )
+    gov.load_documents(session, corpus_dir=tmp_path)
+    rows = {r.name: r for r in gov.repositories(session)}
+
+    assert gov.release_text(rows["qmetronome"]) == "v0.2.0"
+    assert gov.release_text(rows["alfred"]) == "v0.2.0 lightweight +37"
+    assert gov.release_text(rows["qm"]) == "never tagged"
+    assert gov.release_text(rows["mystery"]) == "unknown"
+    assert rows["mystery"].release_unknown == "gh: Not Found"
+
+
+def test_never_tagged_is_not_rendered_as_current(session, tmp_path):
+    """Both have nothing outstanding and they mean opposite things."""
+    write_harness(
+        tmp_path,
+        [
+            {"name": "a", "release": {"state": "unreleased", "latest": None}},
+            {"name": "b", "release": {"state": "current", "latest": "v1.0.0",
+                                      "annotated": True}},
+        ],
+    )
+    gov.load_documents(session, corpus_dir=tmp_path)
+    rows = {r.name: r for r in gov.repositories(session)}
+    assert gov.release_text(rows["a"]) != gov.release_text(rows["b"])
+    assert gov.release_text(rows["a"]) == "never tagged"
+
+
+def test_a_lightweight_tag_is_flagged_wherever_it_is_rendered(session, tmp_path):
+    """It names no reviewer and no manual test, so it is not a release."""
+    write_harness(
+        tmp_path,
+        [{"name": "datum", "release": {"state": "current", "latest": "v0.0.1",
+                                       "annotated": False}}],
+    )
+    gov.load_documents(session, corpus_dir=tmp_path)
+    row = gov.repositories(session)[0]
+    assert "lightweight" in gov.release_text(row)
+    assert any("lightweight" in line for line in gov.summary_lines(row))
+
+
+def test_a_document_with_no_release_layer_leaves_the_columns_empty_not_wrong(
+    session, tmp_path
+):
+    """An older document is a thing nobody measured."""
+    write_harness(tmp_path, [{"name": "old"}])
+    gov.load_documents(session, corpus_dir=tmp_path)
+    row = gov.repositories(session)[0]
+    assert row.release_state is None and row.release_unknown is None
+    assert gov.release_text(row) == "-"


### PR DESCRIPTION
Pairs the dashboard with the org rule: **`main` implies readiness; a `v` tag implies human governance has been passed.**

Reads the `release` layer the corpus's harness document now carries, and renders the gap between the two — commits on a default branch that no tag has asserted.

## States, and the two that must not be collapsed

| Reads | Means |
|---|---|
| `never tagged` | no `v` tag has ever existed; nothing has ever been asserted |
| `v0.2.0` | tagged, annotated, nothing beyond it |
| `v0.2.0 +37` | 37 commits of readiness waiting on governance |
| `v0.0.1 lightweight` | no annotation, so it names neither reviewer nor manual test |
| `unknown` | tags unreadable, reason kept |

`never tagged` and a bare version both have nothing outstanding and mean **opposite** things, so one is never rendered as the other. A lightweight tag is a finding rather than a release: §6 of the version-tags record requires annotated tags precisely because a lightweight one can state no basis.

## What it found on the org, first run

Two lightweight tags — `alfred@v0.2.0` and `datum@v0.0.1` — and nine repositories never tagged.

## Where

Migration `008_release` after `007_reclaim`. One shared `release_text()` so the CLI and TUI cannot disagree. RELEASE column in `governance show` and the Governance tab, plus a release line in the per-project Details block.

## Verified

93 passed, 1 skipped, run twice. All 8 gates pass. Four new tests including a document carrying no release layer at all, which must read as unmeasured rather than untagged.