### PR TITLE
Refresh the seed workflow copies, and cap superseded runs

### DIFF
--- a/.github/workflows/adr-lint.yml
+++ b/.github/workflows/adr-lint.yml
@@ -21,7 +21,7 @@ name: ADR lint
 # Two knobs, both in env: below. Nothing else in this file needs editing.
 #   QM_SUBMODULE -- where this project mounts the governance submodule.
 #                   governance/qm is the documented default; codecartographer
-#                   mounts it at docs/qm, so the path is a project choice and
+#                   mounted it at docs/qm before moving to the seed's path, so this is a
 #                   is named once here rather than repeated per step.
 #   RECORDS_DIR  -- leave empty for the branch-per-project model. Set it to a
 #                   local path (adr) only if this project keeps adr/ in its
@@ -31,6 +31,20 @@ on:
   push:
     branches: [main]
   pull_request:
+
+# One run per branch per workflow. A second push supersedes the first: nobody
+# reads the result of a run whose commit has already been replaced, and the
+# minutes are real -- 55 of this repository's 129 runs on 2026-08-11 came from
+# five iterative pushes to two pull request branches, where only the last
+# mattered.
+#
+# Cancellation is scoped to pull requests deliberately. On the default branch
+# and on a project branch the run IS the record of what that commit reported,
+# and cancelling it to start a newer one destroys the only evidence that the
+# earlier commit was ever checked.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/adr-lint.yml
+++ b/.github/workflows/adr-lint.yml
@@ -21,7 +21,8 @@ name: ADR lint
 # Two knobs, both in env: below. Nothing else in this file needs editing.
 #   QM_SUBMODULE -- where this project mounts the governance submodule.
 #                   governance/qm is the documented default; codecartographer
-#                   mounted it at docs/qm before moving to the seed's path, so this is a
+#                   mounts it at docs/qm on its default branch to this day -- the
+#                   move to the seed's path is in an unmerged pull request -- so this is a
 #                   is named once here rather than repeated per step.
 #   RECORDS_DIR  -- leave empty for the branch-per-project model. Set it to a
 #                   local path (adr) only if this project keeps adr/ in its

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,6 +15,12 @@ on:
     branches: [main]
   pull_request:
 
+# One run per branch per workflow; a second push supersedes the first.
+# Cancellation is scoped to pull requests: on main the run is the record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/reuse-lint.yml
+++ b/.github/workflows/reuse-lint.yml
@@ -25,6 +25,20 @@ on:
     branches: [main]
   pull_request:
 
+# One run per branch per workflow. A second push supersedes the first: nobody
+# reads the result of a run whose commit has already been replaced, and the
+# minutes are real -- 55 of this repository's 129 runs on 2026-08-11 came from
+# five iterative pushes to two pull request branches, where only the last
+# mattered.
+#
+# Cancellation is scoped to pull requests deliberately. On the default branch
+# and on a project branch the run IS the record of what that commit reported,
+# and cancelling it to start a newer one destroys the only evidence that the
+# earlier commit was ever checked.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/submodule-check.yml
+++ b/.github/workflows/submodule-check.yml
@@ -112,7 +112,7 @@ jobs:
             else
               echo "::error::Submodule '$path' is pinned to $sha, which could not be fetched from its remote ($url)."
               echo "::error::Most likely: committed inside the submodule without pushing. Run: (cd $path && git push origin HEAD), then re-push this repo."
-              echo "::error::This check cannot tell that apart from a private submodule remote that an unauthenticated runner cannot read. If the commit IS pushed, run 'git ls-remote $url $sha' locally: output means the pin is fine and this job needs credentials."
+              echo "::error::This check cannot tell that apart from a private submodule remote that an unauthenticated runner cannot read. To tell them apart locally, run: git init -q /tmp/probe && git -C /tmp/probe fetch --depth=1 $url $sha -- success means the pin is fine and this job needs credentials. Do NOT use 'git ls-remote $url $sha': ls-remote matches ref NAMES, so it prints nothing and exits 0 for a commit that is perfectly fine, which reads as confirmation of the failure."
               status=1
             fi
             rm -rf "$scratch"

--- a/.github/workflows/submodule-check.yml
+++ b/.github/workflows/submodule-check.yml
@@ -28,6 +28,20 @@ on:
   push:
   pull_request:
 
+# One run per branch per workflow. A second push supersedes the first: nobody
+# reads the result of a run whose commit has already been replaced, and the
+# minutes are real -- 55 of this repository's 129 runs on 2026-08-11 came from
+# five iterative pushes to two pull request branches, where only the last
+# mattered.
+#
+# Cancellation is scoped to pull requests deliberately. On the default branch
+# and on a project branch the run IS the record of what that commit reported,
+# and cancelling it to start a newer one destroys the only evidence that the
+# earlier commit was ever checked.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Mechanical propagation from the corpus, plus one hand change.

- `adr-lint.yml`, `submodule-check.yml`, `reuse-lint.yml` re-copied from `project-seed/ci/` and byte-identical to it
- picks up `concurrency` and the submodule-check fix that translates an SSH `.gitmodules` URL to HTTPS, because a runner has no SSH key and the check was calling pushed commits unpushed
- `license-check.yml` is this project's own workflow, so it gets the same concurrency block by hand

**Cancellation is scoped to pull requests.** On `main` the run is the record of what that commit reported, and cancelling it to start a newer one destroys the only evidence the earlier commit was checked.

Verified: all 8 gates pass locally, `reuse lint` clean.